### PR TITLE
Feedback changes

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -192,6 +192,8 @@
     },
     "dailyEffortsLimit": {
       "defaultValue": 8,
+      "minValue": 1,
+      "maxValue": 24,
       "type": "Int",
       "metadata": {
         "description": "Maximum timesheet hours that can be filled on a day."

--- a/Source/Microsoft.Teams.Apps.Timesheet.Common/Repositories/Project/IProjectRepository.cs
+++ b/Source/Microsoft.Teams.Apps.Timesheet.Common/Repositories/Project/IProjectRepository.cs
@@ -55,8 +55,10 @@ namespace Microsoft.Teams.Apps.Timesheet.Common.Repositories
         /// Get all active projects whose start date is greater than and end date is less than current date.
         /// </summary>
         /// <param name="managerUserObjectId">The manager user object Id who created a project.</param>
+        /// <param name="startDate">Start date of the date range.</param>
+        /// <param name="endDate">End date of the date range.</param>
         /// <returns>Returns list of projects.</returns>
-        Task<IEnumerable<Project>> GetActiveProjectsAsync(Guid managerUserObjectId);
+        Task<IEnumerable<Project>> GetActiveProjectsAsync(Guid managerUserObjectId, DateTime startDate, DateTime endDate);
 
         /// <summary>
         /// Get project details by project Id.

--- a/Source/Microsoft.Teams.Apps.Timesheet.Common/Repositories/Project/ProjectRepository.cs
+++ b/Source/Microsoft.Teams.Apps.Timesheet.Common/Repositories/Project/ProjectRepository.cs
@@ -54,13 +54,14 @@ namespace Microsoft.Teams.Apps.Timesheet.Common.Repositories
         /// Get all active projects whose start date is greater than and end date is less than current date.
         /// </summary>
         /// <param name="managerUserObjectId">The manager user object Id who created a project.</param>
+        /// <param name="startDate">Start date of the date range.</param>
+        /// <param name="endDate">End date of the date range.</param>
         /// <returns>Returns list of projects.</returns>
-        public async Task<IEnumerable<Project>> GetActiveProjectsAsync(Guid managerUserObjectId)
+        public async Task<IEnumerable<Project>> GetActiveProjectsAsync(Guid managerUserObjectId, DateTime startDate, DateTime endDate)
         {
             return await this.Context.Projects
                 .Where(project => project.CreatedBy.Equals(managerUserObjectId)
-                    && DateTime.UtcNow.Date >= project.StartDate.Date
-                    && DateTime.UtcNow.Date <= project.EndDate.Date)
+                    && ((project.StartDate.Date >= startDate && project.StartDate.Date <= endDate) || (project.StartDate.Date < startDate && project.EndDate.Date >= startDate)))
                 .OrderBy(project => project.CreatedOn)
                 .ToListAsync();
         }

--- a/Source/Microsoft.Teams.Apps.Timesheet.Test/Helpers/ManagerDashboardHelperTests.cs
+++ b/Source/Microsoft.Teams.Apps.Timesheet.Test/Helpers/ManagerDashboardHelperTests.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Teams.Apps.Timesheet.Tests.Helpers
                 .Setup(timesheetRepo => timesheetRepo.GetTimesheetRequestsByProjectIds(It.IsAny<IEnumerable<Guid>>(), It.IsAny<TimesheetStatus>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .Returns(this.approvedTimesheets.AsEnumerable());
             this.projectRepository
-                .Setup(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>()))
+                .Setup(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .Returns(Task.FromResult(new List<Project>
                 {
                     project,
@@ -319,7 +319,7 @@ namespace Microsoft.Teams.Apps.Timesheet.Tests.Helpers
             // ASSERT
             Assert.AreEqual(TestData.ExpectedDashboardProjects.Count(), result.Count());
             this.timesheetRepository.Verify(timesheetRepo => timesheetRepo.GetTimesheetRequestsByProjectIds(It.IsAny<IEnumerable<Guid>>(), It.IsAny<TimesheetStatus>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.AtLeastOnce());
-            this.projectRepository.Verify(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>()), Times.AtLeastOnce());
+            this.projectRepository.Verify(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.AtLeastOnce());
         }
 
         /// <summary>
@@ -336,7 +336,7 @@ namespace Microsoft.Teams.Apps.Timesheet.Tests.Helpers
                 .Setup(timesheetRepo => timesheetRepo.GetTimesheetRequestsByProjectIds(It.IsAny<IEnumerable<Guid>>(), It.IsAny<TimesheetStatus>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .Returns(this.approvedTimesheets.AsEnumerable());
             this.projectRepository
-                .Setup(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>()))
+                .Setup(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .Returns(Task.FromResult(Enumerable.Empty<Project>()));
 
             var managerUserObjectId = Guid.NewGuid();
@@ -348,7 +348,7 @@ namespace Microsoft.Teams.Apps.Timesheet.Tests.Helpers
 
             // ASSERT
             Assert.IsTrue(result.IsNullOrEmpty());
-            this.projectRepository.Verify(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>()), Times.Once());
+            this.projectRepository.Verify(projectRepo => projectRepo.GetActiveProjectsAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Once());
             this.timesheetRepository.Verify(timesheetRepo => timesheetRepo.GetTimesheetRequestsByProjectIds(It.IsAny<IEnumerable<Guid>>(), It.IsAny<TimesheetStatus>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Never());
         }
     }

--- a/Source/Microsoft.Teams.Apps.Timesheet/ClientApp/public/locales/en-US/translation.json
+++ b/Source/Microsoft.Teams.Apps.Timesheet/ClientApp/public/locales/en-US/translation.json
@@ -180,5 +180,7 @@
   "overBillableTargetLabel": "Over {{hour}} hours billable target",
   "overNonBillableTargetLabel": "Over {{hour}} hours non-billable target",
   "targetHourLabel": "Target - {{hour}} hours",
-  "currentHourLabel": "Current - {{hour}} hours"
+  "currentHourLabel": "Current - {{hour}} hours",
+  "noValidTimesheetsToBeSubmitted": "No timesheets found to submit",
+  "invalidSourceDateEffortsErrorMessage": "Save entry for {{sourceDate}} before duplicating"
 }

--- a/Source/Microsoft.Teams.Apps.Timesheet/ClientApp/src/components/fill-timesheet/fill-timesheet.tsx
+++ b/Source/Microsoft.Teams.Apps.Timesheet/ClientApp/src/components/fill-timesheet/fill-timesheet.tsx
@@ -509,6 +509,16 @@ class FillTimesheet extends React.Component<IFillTimesheetProps, IFillTimesheetS
                 return;
             }
 
+            let sourceDateEfforts = getTotalEfforts(sourceDateTimesheet);
+            if (!sourceDateEfforts || sourceDateEfforts === 0) {
+                this.setState((prevState: IFillTimesheetState) => ({
+                    isDuplicatingEfforts: false,
+                    notification: { id: prevState.notification.id + 1, message: this.localize("invalidSourceDateEffortsErrorMessage", { sourceDate: moment(sourceDateTimesheet?.timesheetDate).format("ll") }), type: ActivityStatus.Error }
+                }));
+
+                return;
+            }
+
             let targetDates = selectedWeekdaysToDuplicate.map((userTimesheet: ITimesheet) => userTimesheet.date);
             let sourceDateTotalEfforts = getTotalEfforts(sourceDateTimesheet);
 
@@ -668,6 +678,13 @@ class FillTimesheet extends React.Component<IFillTimesheetProps, IFillTimesheetS
                             notification: { id: prevState.notification.id + 1, message: this.localize("TimesheetSubmitSuccessfulMessage"), type: ActivityStatus.Success }
                         }));
                     });
+                }
+                else if (apiResponse.status === StatusCodes.NOT_FOUND) {
+                    this.setState((prevState: IFillTimesheetState) => ({
+                        isSubmittingTimesheet: false,
+                        isSavingTimesheet: false,
+                        notification: { id: prevState.notification.id + 1, message: this.localize("noValidTimesheetsToBeSubmitted"), type: ActivityStatus.Error }
+                    }));
                 }
                 else {
                     this.setState((prevState: IFillTimesheetState) => ({

--- a/Source/Microsoft.Teams.Apps.Timesheet/ClientApp/src/components/manager-dashboard/manager-dashboard.tsx
+++ b/Source/Microsoft.Teams.Apps.Timesheet/ClientApp/src/components/manager-dashboard/manager-dashboard.tsx
@@ -799,16 +799,6 @@ class ManagerDashboard extends React.Component<IManagerDashboardProps, IManagerD
             </Flex>);
     }
 
-    /**
-     * Converts local date to UTC date.
-     * @param date The date to be converted.
-     */
-    getUtcDate = (date: Date) => {
-        let utcDate = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(),
-            date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds());
-        return new Date(utcDate);
-    }
-
     /** 
      * Gets active and approve projects details for current month 
      */
@@ -819,11 +809,7 @@ class ManagerDashboard extends React.Component<IManagerDashboardProps, IManagerD
         let firstDate = new Date(date.getFullYear(), new Date().getMonth(), 1);
         let endDate = new Date(date.getFullYear(), new Date().getMonth() + 1, 0);
 
-        // Get first date and last date of current month
-        let firstDay = this.getUtcDate(firstDate);
-        let lastDay = this.getUtcDate(endDate);
-
-        let response = await getDashboardProjectsAsync(firstDay, lastDay, this.handleTokenAccessFailure);
+        let response = await getDashboardProjectsAsync(firstDate, endDate, this.handleTokenAccessFailure);
         if (response && response.status === StatusCodes.OK && response.data) {
             this.setState({
                 dashboardProjects: response.data,

--- a/Source/Microsoft.Teams.Apps.Timesheet/Controllers/SettingsController.cs
+++ b/Source/Microsoft.Teams.Apps.Timesheet/Controllers/SettingsController.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Teams.Apps.Timesheet.Controllers
                 {
                     TimesheetFreezeDayOfMonth = this.botOptions.Value.TimesheetFreezeDayOfMonth,
                     WeeklyEffortsLimit = this.botOptions.Value.WeeklyEffortsLimit,
+                    DailyEffortsLimit = this.botOptions.Value.DailyEffortsLimit
                 };
 
                 this.RecordEvent("Get validation parameters- The HTTP GET call to get resources has been succeeded.", RequestType.Succeeded);

--- a/Source/Microsoft.Teams.Apps.Timesheet/Controllers/TimesheetController.cs
+++ b/Source/Microsoft.Teams.Apps.Timesheet/Controllers/TimesheetController.cs
@@ -146,8 +146,8 @@ namespace Microsoft.Teams.Apps.Timesheet.Controllers
                     return this.Ok(result);
                 }
 
-                this.RecordEvent("Submit timesheet- The HTTP POST call to submit timesheet has been failed.", RequestType.Failed);
-                return this.StatusCode((int)HttpStatusCode.InternalServerError, "Unable to submit timesheets.");
+                this.RecordEvent("Submit timesheet- The HTTP POST call to submit timesheet has been failed. No timesheets found to be submitted.", RequestType.Failed);
+                return this.StatusCode((int)HttpStatusCode.NotFound, "Unable to submit timesheets as there are no timesheets found to be submitted.");
             }
             catch (Exception ex)
             {

--- a/Source/Microsoft.Teams.Apps.Timesheet/Helpers/ManagerDashboard/ManagerDashboardHelper.cs
+++ b/Source/Microsoft.Teams.Apps.Timesheet/Helpers/ManagerDashboard/ManagerDashboardHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Teams.Apps.Timesheet.Helpers
         /// <returns>Returns list of dashboard projects.</returns>
         public async Task<IEnumerable<DashboardProjectDTO>> GetDashboardProjectsAsync(Guid managerUserObjectId, DateTime startDate, DateTime endDate)
         {
-            var projects = await this.repositoryAccessors.ProjectRepository.GetActiveProjectsAsync(managerUserObjectId);
+            var projects = await this.repositoryAccessors.ProjectRepository.GetActiveProjectsAsync(managerUserObjectId, startDate, endDate);
 
             if (projects.IsNullOrEmpty())
             {

--- a/Source/Microsoft.Teams.Apps.Timesheet/Models/SettingsDTO.cs
+++ b/Source/Microsoft.Teams.Apps.Timesheet/Models/SettingsDTO.cs
@@ -19,5 +19,10 @@ namespace Microsoft.Teams.Apps.Timesheet.Models
         /// Gets or sets maximum hours can be filled in a week.
         /// </summary>
         public int WeeklyEffortsLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets maximum hours can be filled in a day.
+        /// </summary>
+        public int DailyEffortsLimit { get; set; }
     }
 }

--- a/Source/Microsoft.Teams.Apps.Timesheet/appsettings.json
+++ b/Source/Microsoft.Teams.Apps.Timesheet/appsettings.json
@@ -28,6 +28,7 @@
     "UserPartOfProjectsCacheDurationInHour": 1,
     "TimesheetFreezeDayOfMonth": 10,
     "WeeklyEffortsLimit": 40,
+    "DailyEffortsLimit": 8,
     "ManagerProjectValidationCacheDurationInHours": 12,
     "ManagerReporteesCacheDurationInHours": 1
   },


### PR DESCRIPTION
Following fixes/feedback changes are incorporated in this pull request:
- Daily validation failure at client side: While filling timesheet if user enters hours more than maximum daily hours limit, no error message was getting displayed before making an API call.
- Wrong API response for Save & Submit: When user clears already saved efforts, status of timesheet for that day gets reset to unfilled. On submit call, we fetch saved timesheets. But if no timesheets are found to be submitted then API was returning InternalSeverError which resulted in showing error at client side.
- Get active projects for month rather than current day: Existing manager dashboard showed active projects for current day. Feedback received to show projects for current month. Hence modified repository query which now gets start and end date as parameter
- Added check for source date efforts for duplicating efforts: 
